### PR TITLE
Update CoC to include GH Discussions and Slack

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -38,19 +38,19 @@ behavior and are expected to take appropriate and fair corrective action in
 response to any instances of unacceptable behavior.
 
 Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+reject comments, commits, code, wiki edits, issues, GitHub Discussions posts, 
+and other contributions that are not aligned to this Code of Conduct, or to ban 
+temporarily or permanently any contributor for other behaviors that they deem 
+inappropriate, threatening, offensive, or harmful.
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+This Code of Conduct applies both within project spaces (including the Community Slack
+and GitHub Discussions forums) and in public spaces when an individual is representing the 
+project or its community. Examples of representing a project or community include 
+using an official project e-mail address, posting via an official social media account, 
+or acting as an appointed representative at an online or offline event. Representation 
+of a project may be further defined and clarified by project maintainers.
 
 ## Enforcement
 


### PR DESCRIPTION
This adds to the scope of the Code of Conduct to be inclusive of GitHub Discussions forum as well as the Community Slack 

Signed-off-by: Matt Stratton <matt.stratton@gmail.com>

# Description

This adds to the scope of the Code of Conduct to be inclusive of GitHub Discussions forum as well as the Community Slack

Fixes # (issue)

## Checklist

There are no required tests for this change.
- [ ] I have added tests that prove my fix is effective or that my feature works

- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change

- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version


